### PR TITLE
Fix deprecated type call

### DIFF
--- a/torchsparse_20/backend/convolution/convolution_cuda.cu
+++ b/torchsparse_20/backend/convolution/convolution_cuda.cu
@@ -547,7 +547,7 @@ at::Tensor convolution_forward_cuda_latest(
 
   // all gather
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      in_feat.type(), "convolution_forward_cuda", ([&] {
+      in_feat.scalar_type(), "convolution_forward_cuda", ([&] {
         gather_all_kernel_pad_sep_with_mask<scalar_t>
             <<<ceil((double)(n_in_feats * n_in_channels) /
                     (256 << (sizeof(scalar_t) == 2) + 2)),
@@ -779,7 +779,7 @@ at::Tensor convolution_forward_cuda_fallback(
     // gather n_active_feats dense features from N sparse input features with c
     // feature dimensions
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        in_feat.type(), "convolution_forward_cuda", ([&] {
+        in_feat.scalar_type(), "convolution_forward_cuda", ([&] {
           gather_kernel<scalar_t>
               <<<ceil((double)(n_active_feats * n_in_channels) / 256), 256>>>(
                   n_active_feats, n_in_feats, n_in_channels,
@@ -796,7 +796,7 @@ at::Tensor convolution_forward_cuda_fallback(
     // scatter n_active_feats dense features into n_out_feats output features of
     // dimension n_out_channels
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        in_feat.type(), "convolution_forward_cuda", ([&] {
+        in_feat.scalar_type(), "convolution_forward_cuda", ([&] {
           scatter_kernel<scalar_t>
               <<<ceil((double)(n_active_feats * n_out_channels) / 256), 256>>>(
                   n_active_feats, n_out_feats, n_out_channels,
@@ -877,7 +877,7 @@ void convolution_backward_cuda(at::Tensor in_feat, at::Tensor grad_in_feat,
     }
     // gather
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        in_feat.type(), "convolution_forward_cuda", ([&] {
+        in_feat.scalar_type(), "convolution_forward_cuda", ([&] {
           gather_kernel<scalar_t>
               <<<ceil((double)(n_active_feats * n_out_channels) / 256), 256>>>(
                   n_active_feats, n_out_feats, n_out_channels,
@@ -886,7 +886,7 @@ void convolution_backward_cuda(at::Tensor in_feat, at::Tensor grad_in_feat,
                   neighbor_map.data_ptr<int>() + cur_offset, !transpose);
         }));
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        in_feat.type(), "convolution_forward_cuda", ([&] {
+        in_feat.scalar_type(), "convolution_forward_cuda", ([&] {
           gather_kernel<scalar_t>
               <<<ceil((double)(n_active_feats * n_in_channels) / 256), 256>>>(
                   n_active_feats, n_in_feats, n_in_channels,
@@ -902,7 +902,7 @@ void convolution_backward_cuda(at::Tensor in_feat, at::Tensor grad_in_feat,
                   out_grad_buffer_activated);
     // scatter
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-        in_feat.type(), "convolution_forward_cuda", ([&] {
+        in_feat.scalar_type(), "convolution_forward_cuda", ([&] {
           scatter_kernel<scalar_t>
               <<<ceil((double)(n_active_feats * n_in_channels) / 256), 256>>>(
                   n_active_feats, n_in_feats, n_in_channels,

--- a/torchsparse_20/backend/devoxelize/devoxelize_cuda.cu
+++ b/torchsparse_20/backend/devoxelize/devoxelize_cuda.cu
@@ -68,7 +68,7 @@ at::Tensor devoxelize_forward_cuda(const at::Tensor feat,
       torch::zeros({N, c}, at::device(feat.device()).dtype(feat.dtype()));
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      feat.type(), "devoxelize_forward_cuda", ([&] {
+      feat.scalar_type(), "devoxelize_forward_cuda", ([&] {
         devoxelize_forward_kernel<scalar_t><<<N, c>>>(
             N, c, indices.data_ptr<int>(), weight.data_ptr<scalar_t>(),
             feat.data_ptr<scalar_t>(), out.data_ptr<scalar_t>());
@@ -88,7 +88,7 @@ at::Tensor devoxelize_backward_cuda(const at::Tensor top_grad,
       {n, c}, at::device(top_grad.device()).dtype(top_grad.dtype()));
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      top_grad.type(), "devoxelize_backward_cuda", ([&] {
+      top_grad.scalar_type(), "devoxelize_backward_cuda", ([&] {
         devoxelize_backward_kernel<scalar_t><<<N, c>>>(
             N, n, c, indices.data_ptr<int>(), weight.data_ptr<scalar_t>(),
             top_grad.data_ptr<scalar_t>(), bottom_grad.data_ptr<scalar_t>());

--- a/torchsparse_20/backend/voxelize/voxelize_cuda.cu
+++ b/torchsparse_20/backend/voxelize/voxelize_cuda.cu
@@ -51,7 +51,7 @@ at::Tensor voxelize_forward_cuda(const at::Tensor inputs, const at::Tensor idx,
       torch::zeros({N1, c}, at::device(idx.device()).dtype(inputs.dtype()));
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      inputs.type(), "voxelize_forward_cuda", ([&] {
+      inputs.scalar_type(), "voxelize_forward_cuda", ([&] {
         voxelize_forward_kernel<scalar_t><<<N, c>>>(
             N, c, N1, inputs.data_ptr<scalar_t>(), idx.data_ptr<int>(),
             counts.data_ptr<int>(), out.data_ptr<scalar_t>());
@@ -70,7 +70,7 @@ at::Tensor voxelize_backward_cuda(const at::Tensor top_grad,
       torch::zeros({N, c}, at::device(idx.device()).dtype(top_grad.dtype()));
 
   AT_DISPATCH_FLOATING_TYPES_AND_HALF(
-      top_grad.type(), "voxelize_backward_cuda", ([&] {
+      top_grad.scalar_type(), "voxelize_backward_cuda", ([&] {
         voxelize_backward_kernel<scalar_t><<<N, c>>>(
             N, c, N1, top_grad.data_ptr<scalar_t>(), idx.data_ptr<int>(),
             counts.data_ptr<int>(), bottom_grad.data_ptr<scalar_t>());

--- a/torchsparse_20/nn/functional/conv.py
+++ b/torchsparse_20/nn/functional/conv.py
@@ -2,7 +2,7 @@ from typing import List, Optional, Tuple, Union
 
 import torch
 from torch.autograd import Function
-from torch.cuda.amp import custom_bwd, custom_fwd
+from torch.amp import custom_bwd, custom_fwd
 
 import torchsparse_20
 import torchsparse_20.backend
@@ -18,7 +18,7 @@ __all__ = ['conv3d']
 class ConvolutionFunction(Function):
 
     @staticmethod
-    @custom_fwd(cast_inputs=torch.half)
+    @custom_fwd(cast_inputs=torch.half, device_type='cuda')
     def forward(
         ctx,
         input: torch.Tensor,
@@ -90,7 +90,7 @@ class ConvolutionFunction(Function):
         return output
 
     @staticmethod
-    @custom_bwd
+    @custom_bwd(device_type='cuda')
     def backward(ctx, grad_output: torch.Tensor):
         input, weight, nbmaps, nbsizes, transposed = ctx.for_backwards
 

--- a/torchsparse_20/nn/functional/devoxelize.py
+++ b/torchsparse_20/nn/functional/devoxelize.py
@@ -1,6 +1,6 @@
 import torch
 from torch.autograd import Function
-from torch.cuda.amp import custom_bwd, custom_fwd
+from torch.amp import custom_bwd, custom_fwd
 
 import torchsparse_20.backend
 
@@ -51,7 +51,7 @@ def calc_ti_weights(coords: torch.Tensor,
 class DevoxelizeFunction(Function):
 
     @staticmethod
-    @custom_fwd(cast_inputs=torch.half)
+    @custom_fwd(cast_inputs=torch.half, device_type='cuda')
     def forward(ctx, feats: torch.Tensor, coords: torch.Tensor,
                 weights: torch.Tensor) -> torch.Tensor:
         feats = feats.contiguous()
@@ -73,7 +73,7 @@ class DevoxelizeFunction(Function):
         return output
 
     @staticmethod
-    @custom_bwd
+    @custom_bwd(device_type='cuda')
     def backward(ctx, grad_output: torch.Tensor):
         coords, weights, input_size = ctx.for_backwards
         grad_output = grad_output.contiguous()

--- a/torchsparse_20/nn/functional/voxelize.py
+++ b/torchsparse_20/nn/functional/voxelize.py
@@ -1,6 +1,6 @@
 import torch
 from torch.autograd import Function
-from torch.cuda.amp import custom_bwd, custom_fwd
+from torch.amp import custom_bwd, custom_fwd
 
 import torchsparse_20.backend
 
@@ -10,7 +10,7 @@ __all__ = ['spvoxelize']
 class VoxelizeFunction(Function):
 
     @staticmethod
-    @custom_fwd(cast_inputs=torch.half)
+    @custom_fwd(cast_inputs=torch.half, device_type='cuda')
     def forward(ctx, feats: torch.Tensor, coords: torch.Tensor,
                 counts: torch.Tensor) -> torch.Tensor:
         feats = feats.contiguous()
@@ -31,7 +31,7 @@ class VoxelizeFunction(Function):
         return output
 
     @staticmethod
-    @custom_bwd
+    @custom_bwd(device_type='cuda')
     def backward(ctx, grad_output: torch.Tensor):
         coords, counts, input_size = ctx.for_backwards
         grad_output = grad_output.contiguous()


### PR DESCRIPTION
`type()` was deprecated and removed in the most recent versions of PyTorch in favor of `scalar_type()`.